### PR TITLE
Add flatten.

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,14 @@ Merges the specified *arrays* into a single array. This method is similar to the
 d3_array.merge([[1], [2, 3]]); // returns [1, 2, 3]
 ```
 
+<a name="flatten" href="#flatten">#</a> d3_array.<b>flatten</b>(<i>arrays</i>)
+
+Flattens the specified nested array of *arrays* into a single array. This method is essentially a recursive [merge](#merge) for each input element that is an array.
+
+```js
+d3_array.flatten([1, [[[2, 3], []], 4]]); // returns [1, 2, 3, 4]
+```
+
 <a name="pairs" href="#pairs">#</a> d3_array.<b>pairs</b>(<i>array</i>)
 
 For each adjacent pair of elements in the specified *array*, returns a new array of tuples of element *i* and element *i* - 1. For example:

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ export {default as descending} from "./src/descending";
 export {default as deviation} from "./src/deviation";
 export {default as entries} from "./src/entries";
 export {default as extent} from "./src/extent";
+export {default as flatten} from "./src/flatten";
 export {default as histogram} from "./src/histogram";
 export {default as thresholdFreedmanDiaconis} from "./src/threshold/freedmanDiaconis";
 export {default as thresholdScott} from "./src/threshold/scott";

--- a/src/flatten.js
+++ b/src/flatten.js
@@ -1,16 +1,15 @@
-export default function(arrays) {
-  var queue = [arrays],
-      array,
+export default function(array) {
+  var queue = [],
       result = [];
 
-  while (array = queue.pop()) {
+  do {
     if (Array.isArray(array)) {
       var n = array.length;
       while (--n >= 0) queue.push(array[n]);
     } else {
       result.push(array);
     }
-  }
+  } while (array = queue.pop());
 
   return result;
 };

--- a/src/flatten.js
+++ b/src/flatten.js
@@ -1,0 +1,16 @@
+export default function(arrays) {
+  var queue = [arrays],
+      array,
+      result = [];
+
+  while (array = queue.pop()) {
+    if (Array.isArray(array)) {
+      var n = array.length;
+      while (--n >= 0) queue.push(array[n]);
+    } else {
+      result.push(array);
+    }
+  }
+
+  return result;
+};

--- a/test/flatten-test.js
+++ b/test/flatten-test.js
@@ -1,0 +1,61 @@
+var tape = require("tape"),
+    arrays = require("../");
+
+tape("flatten(array) returns a copy of the input array", function(test) {
+  var a = {}, b = {}, c = {};
+  test.deepEqual(arrays.flatten([a, b, c]), [a, b, c]);
+  test.end();
+});
+
+tape("flatten(arrays) flattens an array of arrays", function(test) {
+  var a = {}, b = {}, c = {}, d = {}, e = {}, f = {};
+  test.deepEqual(arrays.flatten([[a], [b, c], [d, e, f]]), [a, b, c, d, e, f]);
+  test.end();
+});
+
+tape("flatten(arrays) flattens an array of array of arrays", function(test) {
+  var a = {}, b = {}, c = {}, d = {}, e = {}, f = {};
+  test.deepEqual(arrays.flatten([[a], [b, [c]], [[[[[d]], e]], f]]), [a, b, c, d, e, f]);
+  test.end();
+});
+
+tape("flatten(arrays) returns a new array when zero arrays are passed", function(test) {
+  var input = [],
+      output = arrays.flatten(input);
+  test.deepEqual(output, []);
+  input.push([0.1]);
+  test.deepEqual(input, [[0.1]]);
+  test.deepEqual(output, []);
+  test.end();
+});
+
+tape("flatten(arrays) returns a new array when one array is passed", function(test) {
+  var input = [[1, 2, 3]],
+      output = arrays.flatten(input);
+  test.deepEqual(output, [1, 2, 3]);
+  input.push([4.1]);
+  input[0].push(3.1);
+  test.deepEqual(input, [[1, 2, 3, 3.1], [4.1]]);
+  test.deepEqual(output, [1, 2, 3]);
+  test.end();
+});
+
+tape("flatten(arrays) returns a new array when two or more arrays are passed", function(test) {
+  var input = [[1, 2, 3], [4, 5], [6]],
+      output = arrays.flatten(input);
+  test.deepEqual(output, [1, 2, 3, 4, 5, 6]);
+  input.push([7.1]);
+  input[0].push(3.1);
+  input[1].push(5.1);
+  input[2].push(6.1);
+  test.deepEqual(input, [[1, 2, 3, 3.1], [4, 5, 5.1], [6, 6.1], [7.1]]);
+  test.deepEqual(output, [1, 2, 3, 4, 5, 6]);
+  test.end();
+});
+
+tape("flatten(arrays) does not modify the input arrays", function(test) {
+  var input = [[1, 2, 3], [4, 5], [6]];
+  arrays.flatten(input);
+  test.deepEqual(input, [[1, 2, 3], [4, 5], [6]]);
+  test.end();
+});


### PR DESCRIPTION
Flatten is a recursive merge operator. For example, if you want to compute the extent of a stack layout, you can’t simply use extent because you need separate value accessors for the min and max. So, the obvious solution is to call min and max separately:

```js
[
  d3_array.min(series, function(s) { return d3_array.min(s, function(d) { return d[0]; }); }),
  d3_array.max(series, function(s) { return d3_array.max(s, function(d) { return d[1]; }); })
]
```

However, you could instead flatten the series into a single array and then compute the extent directly:

```js
d3_array.extent(d3_array.merge(d3_array.merge(series)))
```

Although more concise, this approach isn’t very efficient because you first create an array of N×M elements (N = number of series, M = number of points per series) and then copy it into an N×M×2 array.

The flatten method proposed in this pull request probably isn’t much more efficient. (It might even be slower because the length of the flattened array isn’t known beforehand, so the array can’t be pre-allocated. Instead, a queue of elements to visit is maintained during traversal. Also, this method will hang if the input array contains itself.)

But it is straightforward and concise, so it might be useful?

```js
d3_array.extent(d3_array.flatten(series))
```

Related note: I’m looking forward to being able to use generators and iterators.