### PR TITLE
pairs checks that second arg is a function

### DIFF
--- a/src/pairs.js
+++ b/src/pairs.js
@@ -1,5 +1,5 @@
 export default function(array, f) {
-  if (f == null) f = pair;
+  if (typeof f !== "function") f = pair;
   var i = 0, n = array.length - 1, p = array[0], pairs = new Array(n < 0 ? 0 : n);
   while (i < n) pairs[i] = f(p, p = array[++i]);
   return pairs;


### PR DESCRIPTION
Before c57a0848ff8bbf8c4cbc8fd544cb9c4ca4ca329f, this worked:

```
var lines = [
  [[10, 20], [20, 90], [30, 40]],
  [[10, 15], [20, 30], [30, 10]],
]

svg.appendMany(lines, 'g').appendMany(d3.pairs, 'path')
  .attrs({d: d => 'M' + d.join('L'), stroke: '#000'})
```

Now `d3.pairs` tries to use the `index` argument from `.data` as a function. Not a huge deal - `.appendMany(d => d3.pairs(d), 'path')` works - but it was nicer before.