### PR TITLE
In d3.histogram, the rightmost bin by default thresholds is too wide

### DIFF
--- a/src/histogram.js
+++ b/src/histogram.js
@@ -30,7 +30,7 @@ export default function() {
     // Convert number of thresholds into uniform thresholds.
     if (!Array.isArray(tz)) {
       tz = tickStep(x0, x1, tz);
-      tz = range(Math.ceil(x0 / tz) * tz, Math.floor(x1 / tz) * tz, tz); // exclusive
+      tz = range(Math.ceil(x0 / tz) * tz, x1, tz); // exclusive
     }
 
     // Remove any thresholds outside the domain.

--- a/test/histogram-test.js
+++ b/test/histogram-test.js
@@ -122,6 +122,18 @@ tape("histogram.thresholds(function) sets the bin thresholds accessor", function
   test.end();
 });
 
+tape("histogram()() returns bins whose rightmost bin is not too wide", function(test) {
+  var h = arrays.histogram();
+  test.deepEqual(h([9.8, 10, 11, 12, 13, 13.2]), [
+    bin([9.8], 9.8, 10),
+    bin([10], 10, 11),
+    bin([11], 11, 12),
+    bin([12], 12, 13),
+    bin([13, 13.2], 13, 13.2),
+  ]);
+  test.end();
+});
+
 function bin(bin, x0, x1)  {
   bin.x0 = x0;
   bin.x1 = x1;


### PR DESCRIPTION
Nice to meet you.

`d3.histogram()(data)` returns bins their width are automatically determined by default thresholds.

I understand that widths of middle bins are fixed and widths of edge bins (leftmost and rightmost) are less or equal to the fixed width. But sometimes the rightmost bin may have wider width.

For example, the result of code below has wider rightmost bin:
```
> d3.histogram()([9.8, 10, 11, 12, 13, 13.2])
[ [ 9.8, x0: 9.8, x1: 10 ], // width: 0.2
  [ 10, x0: 10, x1: 11 ], // width: 1
  [ 11, x0: 11, x1: 12 ], // width: 1
  [ 12, 13, 13.2, x0: 12, x1: 13.2 ] ] // width: 1.2 (!?)
```

I expect that the last part of bins should be:
```
  [ 11, x0: 11, x1: 12 ], // width: 1
  [ 12, x0: 12, x1: 13 ], // width: 1
  [ 13, 13.2, x0: 13, x1: 13.2 ] ] // width: 0.2
```

In [src/hitogram.js#L33](https://github.com/d3/d3-array/blob/544033c59e21b12579af7344a1cecd6d56131a2a/src/histogram.js#L33), the default thresholds are generated by:
```
 tz = range(Math.ceil(x0 / tz) * tz, Math.floor(x1 / tz) * tz, tz); // exclusive
```

I think that this `Math.floor` is not needed because result of `range(a, b, c)` already does not include `b` (isn't it?).
