### PR TITLE
Don’t filter explicit thresholds.

### DIFF
--- a/src/histogram.js
+++ b/src/histogram.js
@@ -14,6 +14,7 @@ export default function() {
   function histogram(data) {
     var i,
         n = data.length,
+        m,
         x,
         values = new Array(n);
 
@@ -27,12 +28,15 @@ export default function() {
         tz = threshold(values, x0, x1);
 
     // Convert number of thresholds into uniform thresholds.
-    if (!Array.isArray(tz)) tz = ticks(x0, x1, tz);
+    if (!Array.isArray(tz)) {
+      m = (tz = ticks(x0, x1, tz)).length;
 
-    // Remove any thresholds outside the domain.
-    var m = tz.length;
-    while (tz[0] <= x0) tz.shift(), --m;
-    while (tz[m - 1] >= x1) tz.pop(), --m;
+      // Remove any thresholds outside the domain.
+      while (tz[0] <= x0) tz.shift(), --m;
+      while (tz[m - 1] >= x1) tz.pop(), --m;
+    } else {
+      m = tz.length;
+    }
 
     var bins = new Array(m + 1),
         bin;

--- a/test/histogram-test.js
+++ b/test/histogram-test.js
@@ -90,6 +90,19 @@ tape("histogram.thresholds(array) sets the bin thresholds", function(test) {
   test.end();
 });
 
+tape("histogram.thresholds(array) does not drop thresholds outside the domain", function(test) {
+  var h = arrays.histogram().thresholds(arrays.range(5));
+  test.deepEqual(h(arrays.range(5)), [
+    bin([], 0, 0),
+    bin([0], 0, 1),
+    bin([1], 1, 2),
+    bin([2], 2, 3),
+    bin([3], 3, 4),
+    bin([4], 4, 4) // Note: inclusive upper bound for last bin.
+  ]);
+  test.end();
+});
+
 tape("histogram.thresholds(function) sets the bin thresholds accessor", function(test) {
   var actual,
       values = [0, 0, 0, 10, 30, 30],


### PR DESCRIPTION
Only filter implicit thresholds by the domain. Fixes #54.