### PR TITLE
Update rollup.js ->  @1.3.0 cause webpack UglifyJs  build error

### DIFF
--- a/src/group.js
+++ b/src/group.js
@@ -1,6 +1,9 @@
 import identity from "./identity";
 import rollup from "./rollup";
 
-export default function group(values, ...keys) {
-  return rollup(values, identity, ...keys);
+export default function group(values) {
+  for (var _len = arguments.length, keys = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+    keys[_key - 1] = arguments[_key];
+  }
+  return rollup.apply(undefined, [values, identity].concat(keys));
 }

--- a/src/rollup.js
+++ b/src/rollup.js
@@ -1,19 +1,24 @@
 function dogroup(values, keyof) {
-  const map = new Map();
-  let index = -1;
-  for (const value of values) {
-    const key = keyof(value, ++index, values);
-    const group = map.get(key);
+  var map = new Map();
+  var index = -1;
+  for (var value in values) {
+    var key = keyof(value, ++index, values);
+    var group = map.get(key);
     if (group) group.push(value);
     else map.set(key, [value]);
   }
   return map;
 }
 
-export default function rollup(values, reduce, ...keys) {
+export default function rollup(values, reduce) {
+  for (var _len = arguments.length, keys = Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
+    keys[_key - 2] = arguments[_key];
+  }
   return (function regroup(values, i) {
     if (i >= keys.length) return reduce(values);
-    const map = dogroup(values, keys[i]);
-    return new Map(Array.from(map, ([k, v]) => [k, regroup(v, i + 1)]));
+    var map = dogroup(values, keys[i]);
+    return new Map(Array.from(map, function(_ref2) {
+        return [_ref2[0], regroup(_ref2[1], i + 1)]
+    }));
   })(values, 0);
 }


### PR DESCRIPTION
There is es6 syntax `let` and `const` in this file,  cause Webpack build error when d3-array@1.3.0 used in project.

> [ Error: static/js/vendor.169496a4301f622e0093.js from UglifyJs