### PR TITLE
Optimize cross

### DIFF
--- a/src/cross.js
+++ b/src/cross.js
@@ -1,8 +1,9 @@
 function* product(head, ...tail) {
   if (tail.length) {
-    for (const h of head) {
-      for (const t of product(...tail)) {
-        yield [h, ...t];
+    const last = tail.pop();
+    for (const h of product(head, ...tail)) {
+      for (const t of last) {
+        yield [...h, t];
       }
     }
   } else {


### PR DESCRIPTION
d3.cross generates cartesian products recursively, at each level of recursion first iterating through the items in the current array and then for each such item recursing to generate the tail of the cartesian product.

This can be sped up by flipping the generator around: first recurse, and for each result iterate through the current array. This avoids generating the intermediate recursion values n times in each recursion step, which should be faster, especially when creating cartesian products of more than two arrays.

A small benchmark illustrates this (here be dragons):

```js
const { cross } = require("d3-array");

for (let i = 0; i < 100000; i++) {
  cross([1, 2, 3, 4], ["a", "b", "c", "d"], [true, false, null, NaN]);
}
```

With my development machine, Node.js v11.1 and the master version of cross the benchmark takes about 2.47 seconds:

```
$ time node benchmark.js 
real	0m2.470s
user	0m2.418s
sys	0m0.067s
```

With the modified version the benchmark takes about 1.69 seconds:

```ah
$ time node benchmark.js 
real	0m1.689s
user	0m1.658s
sys	0m0.072s
```

This implementation keeps the same order of the results as the master version, so e.g. `cross([1, 2], ["a", "b"])` returns `[[1, "a"], [1, "b"], [2, "a"], [2, "b"]]`. If the order is not important (e.g. `cross([1, 2], ["a", "b"])` is allowed to return `[[1, "a"], [2, "a"], [1, "a"], [2, "b"]]`) then the code can be slightly simplified by changing the beginning of product to something like this:

```js
function* product(head, ...tail) {
  if (tail.length) {
    for (const t of product(...tail)) {
      for (const h of head) {
        yield [h, ...t];
...
```