### PR TITLE
Fix cross for iterables which can be only iterated once

### DIFF
--- a/src/cross.js
+++ b/src/cross.js
@@ -1,6 +1,9 @@
 function* product(head, ...rest) {
   if (rest.length) {
-    const tail = rest.pop();
+    let tail = rest.pop();
+    if (!Array.isArray(tail)) {
+      tail = Array.from(tail);
+    }
     for (const p of product(head, ...rest)) {
       for (const t of tail) {
         yield [...p, t];

--- a/test/cross-test.js
+++ b/test/cross-test.js
@@ -6,6 +6,14 @@ tape("cross(a, b) returns Cartesian product a×b", function(test) {
   test.end();
 });
 
+tape("cross(a, b) returns Cartesian product a×b for iterables which can only iterate once", function(test) {
+  function *gen(...values) {
+    yield *values;
+  }
+  test.deepEqual(arrays.cross(gen(1, 2), gen("x", "y")), [[1, "x"], [1, "y"], [2, "x"], [2, "y"]]);
+  test.end();
+});
+
 tape("cross(a, b, c) returns Cartesian product a×b×c", function(test) {
   test.deepEqual(arrays.cross([1, 2], [3, 4], [5, 6, 7]), [
     [1, 3, 5],


### PR DESCRIPTION
The documentation states that cross returns the Cartesian product of the specified iterables. Some iterables, such as generators, can be iterated through only once. The current implementation of cross returns invalid results:

```js
const { cross } = require("d3-array");

function *gen(...values) {
  yield *values;
}

cross(gen(1, 2), gen("x", "y"));  // [ [ 1, 'x' ], [ 1, 'y' ] ]
```

This pull request adds a new test and fixes cross by first turning non-array iterable arguments into arrays. As a small optimization array arguments are used as-is.