### PR TITLE
Fix cross for zero arguments and zero-length arguments

### DIFF
--- a/src/cross.js
+++ b/src/cross.js
@@ -11,10 +11,15 @@ function reducer(reduce) {
 }
 
 export default function cross(...values) {
-  const reduce = typeof values[values.length - 1] === "function" && reducer(values.pop());
+  const reduce = typeof values[values.length - 1] === "function" && reducer(values.pop())
+
   values = values.map(arrayify);
   const lengths = values.map(length);
   const j = values.length - 1;
+  if (j < 0 || lengths.some(l => l === 0)) {
+    return [];
+  }
+
   const index = new Array(j + 1).fill(0);
   const product = [];
   while (true) {

--- a/test/cross-test.js
+++ b/test/cross-test.js
@@ -1,6 +1,21 @@
 var tape = require("tape"),
     arrays = require("../");
 
+tape("cross() returns an empty array", function(test) {
+  test.deepEqual(arrays.cross(), []);
+  test.end();
+});
+
+tape("cross([]) returns an empty array", function(test) {
+  test.deepEqual(arrays.cross([]), []);
+  test.end();
+});
+
+tape("cross([1, 2], []) returns an empty array", function(test) {
+  test.deepEqual(arrays.cross([1, 2], []), []);
+  test.end();
+});
+
 tape("cross(a, b) returns Cartesian product a×b", function(test) {
   test.deepEqual(arrays.cross([1, 2], ["x", "y"]), [[1, "x"], [1, "y"], [2, "x"], [2, "y"]]);
   test.end();


### PR DESCRIPTION
The current master version of cross loops infinitely when there are no arguments or any of the arguments is zero-length. This pull request adds a couple of checks to handle such cases as well as three tests for future reference.