### PR TITLE
Remove redundant fill.

### DIFF
--- a/src/fsum.js
+++ b/src/fsum.js
@@ -1,7 +1,7 @@
 // https://github.com/python/cpython/blob/a74eea238f5baba15797e2e8b570d153bc8690a7/Modules/mathmodule.c#L1423
 export class Adder {
   constructor() {
-    this._partials = new Float64Array(32).fill(0);
+    this._partials = new Float64Array(32);
     this._n = 0;
   }
   add(x) {


### PR DESCRIPTION
Typed arrays are initialized to zero by default, so this fill is unnecessary.