### PR TITLE
Add d3.shuffler.

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,6 +555,17 @@ d3.permute(object, fields); // returns ["University Farm", "Manchuria", 27]
 
 Randomizes the order of the specified *array* in-place using the [Fisher–Yates shuffle](https://bost.ocks.org/mike/shuffle/) and returns the *array*. If *start* is specified, it is the starting index (inclusive) of the *array* to shuffle; if *start* is not specified, it defaults to zero. If *stop* is specified, it is the ending index (exclusive) of the *array* to shuffle; if *stop* is not specified, it defaults to *array*.length. For example, to shuffle the first ten elements of the *array*: shuffle(*array*, 0, 10).
 
+<a name="shuffler" href="#shuffler">#</a> d3.<b>shuffler</b>(<i>random</i>) · [Source](https://github.com/d3/d3-array/blob/master/src/shuffle.js)
+
+Returns a [shuffle function](#shuffle) given the specified random source. For example, using [d3.randomLcg](https://github.com/d3/d3-random/blob/master/README.md#randomLcg):
+
+```js
+const random = d3.randomLcg(0.9051667019185816);
+const shuffle = d3.shuffler(random);
+
+shuffle([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]); // returns [7, 4, 5, 3, 9, 0, 6, 1, 2, 8]
+```
+
 <a name="ticks" href="#ticks">#</a> d3.<b>ticks</b>(<i>start</i>, <i>stop</i>, <i>count</i>) · [Source](https://github.com/d3/d3-array/blob/master/src/ticks.js), [Examples](https://observablehq.com/@d3/d3-ticks)
 
 Returns an array of approximately *count* + 1 uniformly-spaced, nicely-rounded values between *start* and *stop* (inclusive). Each value is a power of ten multiplied by 1, 2 or 5. See also [d3.tickIncrement](#tickIncrement), [d3.tickStep](#tickStep) and [*linear*.ticks](https://github.com/d3/d3-scale/blob/master/README.md#linear_ticks).

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ export {default as leastIndex} from "./leastIndex.js";
 export {default as greatest} from "./greatest.js";
 export {default as greatestIndex} from "./greatestIndex.js";
 export {default as scan} from "./scan.js"; // Deprecated; use leastIndex.
-export {default as shuffle} from "./shuffle.js";
+export {default as shuffle, shuffler} from "./shuffle.js";
 export {default as sum} from "./sum.js";
 export {default as ticks, tickIncrement, tickStep} from "./ticks.js";
 export {default as transpose} from "./transpose.js";

--- a/src/shuffle.js
+++ b/src/shuffle.js
@@ -1,14 +1,13 @@
-export default function shuffle(array, i0 = 0, i1 = array.length) {
-  var m = i1 - (i0 = +i0),
-      t,
-      i;
+export default shuffler(Math.random);
 
-  while (m) {
-    i = Math.random() * m-- | 0;
-    t = array[m + i0];
-    array[m + i0] = array[i + i0];
-    array[i + i0] = t;
-  }
-
-  return array;
+export function shuffler(random) {
+  return function shuffle(array, i0 = 0, i1 = array.length) {
+    let m = i1 - (i0 = +i0);
+    while (m) {
+      const i = random() * m-- | 0, t = array[m + i0];
+      array[m + i0] = array[i + i0];
+      array[i + i0] = t;
+    }
+    return array;
+  };
 }

--- a/test/shuffle-test.js
+++ b/test/shuffle-test.js
@@ -1,32 +1,30 @@
 const tape = require("tape-await");
 const d3 = Object.assign({}, require("../"), require("d3-random"));
 
-tape("shuffle(array) shuffles the array in-place", withRandom((test) => {
+tape("shuffle(array) shuffles the array in-place", (test) => {
   const numbers = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-  test.equal(d3.shuffle(numbers), numbers);
+  const shuffle = d3.shuffler(d3.randomLcg(0.9051667019185816));
+  test.equal(shuffle(numbers), numbers);
+  test.true(d3.pairs(numbers).some(([a, b]) => a > b)); // shuffled
+});
+
+tape("shuffler(random)(array) shuffles the array in-place", (test) => {
+  const numbers = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+  const shuffle = d3.shuffler(d3.randomLcg(0.9051667019185816));
+  test.equal(shuffle(numbers), numbers);
   test.deepEqual(numbers, [7, 4, 5, 3, 9, 0, 6, 1, 2, 8]);
-}));
+});
 
-tape("shuffle(array, start) shuffles the subset array[start:] in-place", withRandom((test) => {
+tape("shuffler(random)(array, start) shuffles the subset array[start:] in-place", (test) => {
   const numbers = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-  test.equal(d3.shuffle(numbers, 4), numbers);
+  const shuffle = d3.shuffler(d3.randomLcg(0.9051667019185816));
+  test.equal(shuffle(numbers, 4), numbers);
   test.deepEqual(numbers, [0, 1, 2, 3, 8, 7, 6, 4, 5, 9]);
-}));
+});
 
-tape("shuffle(array, start, end) shuffles the subset array[start:end] in-place", withRandom((test) => {
+tape("shuffler(random)(array, start, end) shuffles the subset array[start:end] in-place", (test) => {
   const numbers = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-  test.equal(d3.shuffle(numbers, 3, 8), numbers);
+  const shuffle = d3.shuffler(d3.randomLcg(0.9051667019185816));
+  test.equal(shuffle(numbers, 3, 8), numbers);
   test.deepEqual(numbers, [0, 1, 2, 5, 6, 3, 4, 7, 8, 9]);
-}));
-
-function withRandom(callback) {
-  return function() {
-    const random = Math.random;
-    Math.random = d3.randomLcg(0.9051667019185816);
-    try {
-      return callback.apply(this, arguments);
-    } finally {
-      Math.random = random;
-    }
-  };
-}
+});


### PR DESCRIPTION
Testing the nondeterministic version isn’t feasible because Math.random is captured on load (so monkey-patching no longer works, but there was no documented guarantee that would work anyway). So the nondeterministic test checks that the data isn’t sorted which should only fail 1 out of 10! = 3,628,800 times.

fixes #167