### PR TITLE
Nice fractional bins.

### DIFF
--- a/src/bin.js
+++ b/src/bin.js
@@ -3,8 +3,7 @@ import bisect from "./bisect.js";
 import constant from "./constant.js";
 import extent from "./extent.js";
 import identity from "./identity.js";
-import range from "./range.js";
-import {tickStep} from "./ticks.js";
+import ticks from "./ticks.js";
 import sturges from "./threshold/sturges.js";
 
 export default function() {
@@ -31,8 +30,8 @@ export default function() {
 
     // Convert number of thresholds into uniform thresholds.
     if (!Array.isArray(tz)) {
-      tz = tickStep(x0, x1, tz);
-      tz = range(Math.ceil(x0 / tz) * tz, x1, tz); // exclusive
+      tz = ticks(x0, x1, tz);
+      if (tz[tz.length - 1] === x1) tz.pop(); // exclusive
     }
 
     // Remove any thresholds outside the domain.

--- a/test/bin-test.js
+++ b/test/bin-test.js
@@ -126,6 +126,17 @@ tape("bin.thresholds(function) sets the bin thresholds accessor", (test) => {
   ]);
 });
 
+tape("bin(data) uses nice thresholds", (test) => {
+  const h = d3.bin().domain([0, 1]).thresholds(5);
+  test.deepEqual(h([]).map(b => [b.x0, b.x1]), [
+    [0.0, 0.2],
+    [0.2, 0.4],
+    [0.4, 0.6],
+    [0.6, 0.8],
+    [0.8, 1.0]
+  ]);
+});
+
 tape("bin()() returns bins whose rightmost bin is not too wide", (test) => {
   const h = d3.bin();
   test.deepEqual(h([9.8, 10, 11, 12, 13, 13.2]), [


### PR DESCRIPTION
This brings the improvement of 04cf783bd715cae89303173d50a28fda38c24a9b of d3.ticks to d3.bin, guaranteeing consistency. Before, five bins covering [0, 1]:

```json
[ [ 0, 0.2 ], [ 0.2, 0.4 ], [ 0.4, 0.6000000000000001 ], [ 0.6000000000000001, 0.8 ], [ 0.8, 1 ] ]
```

After:

```json
[ [ 0, 0.2 ], [ 0.2, 0.4 ], [ 0.4, 0.6 ], [ 0.6, 0.8 ], [ 0.8, 1 ] ]
```