### PR TITLE
Allow multiple accessors with sort.

### DIFF
--- a/README.md
+++ b/README.md
@@ -690,7 +690,7 @@ d3.reverse(new Set([0, 2, 3, 1])) // [1, 3, 2, 0]
 ```
 
 <a name="sort" href="#sort">#</a> d3.<b>sort</b>(<i>iterable</i>, <i>comparator</i> = d3.ascending) · [Source](https://github.com/d3/d3-array/blob/master/src/sort.js)
-<br><a name="sort" href="#sort">#</a> d3.<b>sort</b>(<i>iterable</i>, <i>accessor</i>)
+<br><a name="sort" href="#sort">#</a> d3.<b>sort</b>(<i>iterable</i>, ...<i>accessors</i>)
 
 Returns an array containing the values in the given *iterable* in the sorted order defined by the given *comparator* or *accessor* function. If *comparator* is not specified, it defaults to [d3.ascending](#ascending). Equivalent to [*array*.sort](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort), except that it does not mutate the given *iterable*, and the comparator defaults to natural order instead of lexicographic order:
 
@@ -710,7 +710,19 @@ it is equivalent to a *comparator* using [natural order](#ascending):
 d3.sort(data, (a, b) => d3.ascending(a.value, b.value))
 ```
 
-The *accessor* is only invoked once per element, and thus may be nondeterministic.
+The *accessor* is only invoked once per element, and thus the returned sorted order is consistent even if the accessor is nondeterministic.
+
+Multiple accessors may be specified to break ties:
+
+```js
+d3.sort(points, ({x}) => x, ({y}) => y)
+```
+
+This is equivalent to:
+
+```js
+d3.sort(data, (a, b) => d3.ascending(a.x, b.x) || d3.ascending(a.y, b.y))
+```
 
 ### Sets
 

--- a/src/sort.js
+++ b/src/sort.js
@@ -1,18 +1,25 @@
 import ascending from "./ascending.js";
 import permute from "./permute.js";
 
-export default function sort(values, ...order) {
+export default function sort(values, ...F) {
   if (typeof values[Symbol.iterator] !== "function") throw new TypeError("values is not iterable");
   values = Array.from(values);
-  const [f = ascending] = order;
-  if (f.length === 1 || order.length > 1) {
-    order = order.map(f => values.map(f));
-    return permute(values, values.map((d, i) => i).sort((i, j) => {
-      for (const f of order) {
-        const c = ascending(f[i], f[j]);
-        if (c) return c;
-      }
-    }));
+  let [f = ascending] = F;
+  if (f.length === 1 || F.length > 1) {
+    const index = Uint32Array.from(values, (d, i) => i);
+    if (F.length > 1) {
+      F = F.map(f => values.map(f));
+      index.sort((i, j) => {
+        for (const f of F) {
+          const c = ascending(f[i], f[j]);
+          if (c) return c;
+        }
+      });
+    } else {
+      f = values.map(f);
+      index.sort((i, j) => ascending(f[i], f[j]));
+    }
+    return permute(values, index);
   }
   return values.sort(f);
 }

--- a/src/sort.js
+++ b/src/sort.js
@@ -1,12 +1,18 @@
 import ascending from "./ascending.js";
 import permute from "./permute.js";
 
-export default function sort(values, f = ascending) {
+export default function sort(values, ...order) {
   if (typeof values[Symbol.iterator] !== "function") throw new TypeError("values is not iterable");
   values = Array.from(values);
-  if (f.length === 1) {
-    f = values.map(f);
-    return permute(values, values.map((d, i) => i).sort((i, j) => ascending(f[i], f[j])));
+  const [f = ascending] = order;
+  if (f.length === 1 || order.length > 1) {
+    order = order.map(f => values.map(f));
+    return permute(values, values.map((d, i) => i).sort((i, j) => {
+      for (const f of order) {
+        const c = ascending(f[i], f[j]);
+        if (c) return c;
+      }
+    }));
   }
   return values.sort(f);
 }

--- a/test/sort-test.js
+++ b/test/sort-test.js
@@ -17,6 +17,11 @@ tape("sort(values, accessor) uses the specified accessor in natural order", (tes
   test.deepEqual(d3.sort([1, 3, 2, 5, 4], d => -d), [5, 4, 3, 2, 1]);
 });
 
+tape("sort(values, ...accessors) accepts multiple accessors", (test) => {
+  test.deepEqual(d3.sort([[1, 0], [2, 1], [2, 0], [1, 1], [3, 0]], ([x]) => x, ([, y]) => y), [[1, 0], [1, 1], [2, 0], [2, 1], [3, 0]]);
+  test.deepEqual(d3.sort([{x: 1, y: 0}, {x: 2, y: 1}, {x: 2, y: 0}, {x: 1, y: 1}, {x: 3, y: 0}], ({x}) => x, ({y}) => y), [{x: 1, y: 0}, {x: 1, y: 1}, {x: 2, y: 0}, {x: 2, y: 1}, {x: 3, y: 0}]);
+});
+
 tape("sort(values, comparator) uses the specified comparator", (test) => {
   test.deepEqual(d3.sort([1, 3, 2, 5, 4], d3.descending), [5, 4, 3, 2, 1]);
 });


### PR DESCRIPTION
While a comparator can easily express an order across multiple dimensions, the same is not easily done with an accessor. For example, given the following data structure:

```js
points = [[1, 0], [2, 1], [2, 0], [1, 1], [3, 0]]
```

we can say:

```js
d3.sort(points, ([ax, ay], [bx, by]) => d3.ascending(ax, bx) || d3.ascending(ay, by))
```

But there’s no equivalent way to express this an accessor (without making assumptions about the extent of x and y). And that’s a shame because accessors are much more concise to express:

```js
d3.sort(points, ([x]) => x)
```

So, now d3.sort can accept multiple accessors to break ties:

```js
d3.sort(points, ([x]) => x, ([, y]) => y)
```
