### PR TITLE
fixed d3.range(0, 1, 1/49) returns 50 elements!

### DIFF
--- a/src/range.js
+++ b/src/range.js
@@ -2,9 +2,14 @@ export default function(start, stop, step) {
   start = +start, stop = +stop, step = (n = arguments.length) < 2 ? (stop = start, start = 0, 1) : n < 3 ? 1 : +step;
 
   var i = -1,
-      n = Math.max(0, Math.ceil((stop - start) / step)) | 0,
-      range = new Array(n);
-
+      n = (stop - start) / step,
+      floor_n = Math.floor(n);
+  
+  if(n > 0 && n - floor_n < 1e-10) n = floor_n;//so that d3.range(0, 1, 1/49) returns 49 elements!
+  else n = Math.max(0, Math.ceil(n)) | 0;
+      
+  var range = new Array(n);
+  
   while (++i < n) {
     range[i] = start + i * step;
   }


### PR DESCRIPTION
`d3.range(0, 1, step)` is frequently used scenario and I think we should fixed it.