### PR TITLE
use ascendingDefined when sorting by accessor

### DIFF
--- a/src/sort.js
+++ b/src/sort.js
@@ -4,7 +4,7 @@ import permute from "./permute.js";
 export default function sort(values, ...F) {
   if (typeof values[Symbol.iterator] !== "function") throw new TypeError("values is not iterable");
   values = Array.from(values);
-  let [f = ascending] = F;
+  let [f = ascendingDefined] = F;
   if (f.length === 1 || F.length > 1) {
     const index = Uint32Array.from(values, (d, i) => i);
     if (F.length > 1) {
@@ -17,9 +17,17 @@ export default function sort(values, ...F) {
       });
     } else {
       f = values.map(f);
-      index.sort((i, j) => ascending(f[i], f[j]));
+      index.sort((i, j) => ascendingDefined(f[i], f[j]));
     }
     return permute(values, index);
   }
   return values.sort(f);
+}
+
+function defined(x) {
+  return x != null && !Number.isNaN(x);
+}
+
+function ascendingDefined(a, b) {
+  return defined(b) - defined(a) || ascending(a, b);
 }

--- a/test/sort-test.js
+++ b/test/sort-test.js
@@ -1,5 +1,5 @@
 import assert from "assert";
-import {descending, sort} from "../src/index.js";
+import {ascending, descending, sort} from "../src/index.js";
 
 it("sort(values) returns a sorted copy", () => {
   const input = [1, 3, 2, 5, 4];
@@ -46,4 +46,19 @@ it("sort(values, comparator) enforces that comparator is a function", () => {
 
 it("sort(values) does not skip sparse elements", () => {
   assert.deepStrictEqual(sort([, 1, 2,, ]), [1, 2, undefined, undefined]);
+});
+
+it("null, undefined are sorted to the end", () => {
+  assert.deepStrictEqual(sort([1, 2, null, -1, 3]), [-1, 1, 2, 3, null]);
+  assert.deepStrictEqual(sort([1, 2, undefined, -1, 3]), [-1, 1, 2, 3, undefined]);
+});
+
+it("null, undefined are sorted to the end (accessor)", () => {
+  assert.deepStrictEqual(sort([1, 2, null, -1, 3], d => d), [-1, 1, 2, 3, null]);
+  assert.deepStrictEqual(sort([1, 2, undefined, -1, 3], d => d), [-1, 1, 2, 3, undefined]);
+});
+
+it("null, undefined are not expected to be sorted to the end (comparator)", () => {
+  assert.notDeepStrictEqual(sort([1, 2, null, -1, 3], ascending), [-1, 1, 2, 3, null]);
+  // assert.notDeepStrictEqual(sort([1, 2, undefined, -1, 3], ascending), [-1, 1, 2, 3, undefined]);
 });


### PR DESCRIPTION
use ascendingDefined when we sort with an accessor (and the default identity)

closes #217