### PR TITLE
no anonymous default exports

### DIFF
--- a/src/ascending.js
+++ b/src/ascending.js
@@ -1,4 +1,4 @@
-export default function(a, b) {
+export default function ascending(a, b) {
   return a == null || b == null ? NaN
     : a < b ? -1
     : a > b ? 1

--- a/src/bin.js
+++ b/src/bin.js
@@ -7,7 +7,7 @@ import nice from "./nice.js";
 import ticks, {tickIncrement} from "./ticks.js";
 import sturges from "./threshold/sturges.js";
 
-export default function() {
+export default function bin() {
   var value = identity,
       domain = extent,
       threshold = sturges;

--- a/src/bisector.js
+++ b/src/bisector.js
@@ -1,6 +1,6 @@
 import ascending from "./ascending.js";
 
-export default function(f) {
+export default function bisector(f) {
   let delta = f;
   let compare = f;
 

--- a/src/constant.js
+++ b/src/constant.js
@@ -1,5 +1,3 @@
-export default function(x) {
-  return function() {
-    return x;
-  };
+export default function constant(x) {
+  return () => x;
 }

--- a/src/descending.js
+++ b/src/descending.js
@@ -1,4 +1,4 @@
-export default function(a, b) {
+export default function descending(a, b) {
   return a == null || b == null ? NaN
     : b < a ? -1
     : b > a ? 1

--- a/src/extent.js
+++ b/src/extent.js
@@ -1,4 +1,4 @@
-export default function(values, valueof) {
+export default function extent(values, valueof) {
   let min;
   let max;
   if (valueof === undefined) {

--- a/src/identity.js
+++ b/src/identity.js
@@ -1,3 +1,3 @@
-export default function(x) {
+export default function identity(x) {
   return x;
 }

--- a/src/median.js
+++ b/src/median.js
@@ -1,5 +1,5 @@
 import quantile from "./quantile.js";
 
-export default function(values, valueof) {
+export default function median(values, valueof) {
   return quantile(values, 0.5, valueof);
 }

--- a/src/mode.js
+++ b/src/mode.js
@@ -1,6 +1,6 @@
 import {InternMap} from "internmap";
 
-export default function(values, valueof) {
+export default function mode(values, valueof) {
   const counts = new InternMap();
   if (valueof === undefined) {
     for (let value of values) {

--- a/src/number.js
+++ b/src/number.js
@@ -1,4 +1,4 @@
-export default function(x) {
+export default function number(x) {
   return x === null ? NaN : +x;
 }
 

--- a/src/permute.js
+++ b/src/permute.js
@@ -1,3 +1,3 @@
-export default function(source, keys) {
+export default function permute(source, keys) {
   return Array.from(keys, key => source[key]);
 }

--- a/src/range.js
+++ b/src/range.js
@@ -1,4 +1,4 @@
-export default function(start, stop, step) {
+export default function range(start, stop, step) {
   start = +start, stop = +stop, step = (n = arguments.length) < 2 ? (stop = start, start = 0, 1) : n < 3 ? 1 : +step;
 
   var i = -1,

--- a/src/threshold/freedmanDiaconis.js
+++ b/src/threshold/freedmanDiaconis.js
@@ -1,6 +1,6 @@
 import count from "../count.js";
 import quantile from "../quantile.js";
 
-export default function(values, min, max) {
+export default function thresholdFreedmanDiaconis(values, min, max) {
   return Math.ceil((max - min) / (2 * (quantile(values, 0.75) - quantile(values, 0.25)) * Math.pow(count(values), -1 / 3)));
 }

--- a/src/threshold/scott.js
+++ b/src/threshold/scott.js
@@ -1,6 +1,6 @@
 import count from "../count.js";
 import deviation from "../deviation.js";
 
-export default function(values, min, max) {
+export default function thresholdScott(values, min, max) {
   return Math.ceil((max - min) / (3.5 * deviation(values) * Math.pow(count(values), -1 / 3)));
 }

--- a/src/threshold/sturges.js
+++ b/src/threshold/sturges.js
@@ -1,5 +1,5 @@
 import count from "../count.js";
 
-export default function(values) {
+export default function thresholdSturges(values) {
   return Math.ceil(Math.log(count(values)) / Math.LN2) + 1;
 }

--- a/src/ticks.js
+++ b/src/ticks.js
@@ -2,7 +2,7 @@ var e10 = Math.sqrt(50),
     e5 = Math.sqrt(10),
     e2 = Math.sqrt(2);
 
-export default function(start, stop, count) {
+export default function ticks(start, stop, count) {
   var reverse,
       i = -1,
       n,

--- a/src/transpose.js
+++ b/src/transpose.js
@@ -1,6 +1,6 @@
 import min from "./min.js";
 
-export default function(matrix) {
+export default function transpose(matrix) {
   if (!(n = matrix.length)) return [];
   for (var i = -1, m = min(matrix, length), transpose = new Array(m); ++i < m;) {
     for (var j = -1, n, row = transpose[i] = new Array(n); ++j < n;) {

--- a/src/zip.js
+++ b/src/zip.js
@@ -1,5 +1,5 @@
 import transpose from "./transpose.js";
 
-export default function() {
+export default function zip() {
   return transpose(arguments);
 }


### PR DESCRIPTION
This is mainly to appease limitations of hot module reload systems (Webpack I think?). I don’t really like having to do this—I don’t know why Webpack et al. can’t treat the default export as an arbitrary name and just work rather than warn, but, whatever… seems easy to fix regardless.

I considered using eslint-plugin-import here, which has a rule for this. But it pulls in many trivial (dev) dependencies and doesn’t seem worth it.