### PR TITLE
adopt interning for set operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -765,7 +765,7 @@ This methods implement basic set operations for any iterable.
 
 <a name="difference" href="#difference">#</a> d3.<b>difference</b>(<i>iterable</i>, ...<i>others</i>) · [Source](https://github.com/d3/d3-array/blob/master/src/difference.js)
 
-Returns a new Set containing every value in *iterable* that is not in any of the *others* iterables.
+Returns a new InternSet containing every value in *iterable* that is not in any of the *others* iterables.
 
 ```js
 d3.difference([0, 1, 2, 0], [1]) // Set {0, 2}
@@ -773,7 +773,7 @@ d3.difference([0, 1, 2, 0], [1]) // Set {0, 2}
 
 <a name="union" href="#union">#</a> d3.<b>union</b>(...<i>iterables</i>) · [Source](https://github.com/d3/d3-array/blob/master/src/union.js)
 
-Returns a new Set containing every (distinct) value that appears in any of the given *iterables*. The order of values in the returned Set is based on their first occurrence in the given *iterables*.
+Returns a new InternSet containing every (distinct) value that appears in any of the given *iterables*. The order of values in the returned set is based on their first occurrence in the given *iterables*.
 
 ```js
 d3.union([0, 2, 1, 0], [1, 3]) // Set {0, 2, 1, 3}
@@ -781,7 +781,7 @@ d3.union([0, 2, 1, 0], [1, 3]) // Set {0, 2, 1, 3}
 
 <a name="intersection" href="#intersection">#</a> d3.<b>intersection</b>(...<i>iterables</i>) · [Source](https://github.com/d3/d3-array/blob/master/src/intersection.js)
 
-Returns a new Set containing every (distinct) value that appears in all of the given *iterables*. The order of values in the returned Set is based on their first occurrence in the given *iterables*.
+Returns a new InternSet containing every (distinct) value that appears in all of the given *iterables*. The order of values in the returned set is based on their first occurrence in the given *iterables*.
 
 ```js
 d3.intersection([0, 2, 1, 0], [1, 3]) // Set {1}

--- a/src/difference.js
+++ b/src/difference.js
@@ -1,5 +1,7 @@
+import {InternSet} from "internmap";
+
 export default function difference(values, ...others) {
-  values = new Set(values);
+  values = new InternSet(values);
   for (const other of others) {
     for (const value of other) {
       values.delete(value);

--- a/src/disjoint.js
+++ b/src/disjoint.js
@@ -1,5 +1,7 @@
+import {InternSet} from "internmap";
+
 export default function disjoint(values, other) {
-  const iterator = other[Symbol.iterator](), set = new Set();
+  const iterator = other[Symbol.iterator](), set = new InternSet();
   for (const v of values) {
     if (set.has(v)) return false;
     let value, done;

--- a/src/intersection.js
+++ b/src/intersection.js
@@ -1,7 +1,7 @@
-import set from "./set.js";
+import {InternSet} from "internmap";
 
 export default function intersection(values, ...others) {
-  values = new Set(values);
+  values = new InternSet(values);
   others = others.map(set);
   out: for (const value of values) {
     for (const other of others) {
@@ -12,4 +12,8 @@ export default function intersection(values, ...others) {
     }
   }
   return values;
+}
+
+function set(values) {
+  return values instanceof InternSet ? values : new InternSet(values);
 }

--- a/src/set.js
+++ b/src/set.js
@@ -1,3 +1,0 @@
-export default function set(values) {
-  return values instanceof Set ? values : new Set(values);
-}

--- a/src/superset.js
+++ b/src/superset.js
@@ -1,13 +1,19 @@
 export default function superset(values, other) {
   const iterator = values[Symbol.iterator](), set = new Set();
   for (const o of other) {
-    if (set.has(o)) continue;
+    const io = intern(o);
+    if (set.has(io)) continue;
     let value, done;
     while (({value, done} = iterator.next())) {
       if (done) return false;
-      set.add(value);
-      if (Object.is(o, value)) break;
+      const ivalue = intern(value);
+      set.add(ivalue);
+      if (Object.is(io, ivalue)) break;
     }
   }
   return true;
+}
+
+function intern(value) {
+  return value !== null && typeof value === "object" ? value.valueOf() : value;
 }

--- a/src/union.js
+++ b/src/union.js
@@ -1,5 +1,7 @@
+import {InternSet} from "internmap";
+
 export default function union(...others) {
-  const set = new Set();
+  const set = new InternSet();
   for (const other of others) {
     for (const o of other) {
       set.add(o);

--- a/test/asserts.js
+++ b/test/asserts.js
@@ -1,12 +1,9 @@
 import assert from "assert";
+import {InternSet} from "internmap";
 
-export function assertSetEqual(A, B) {
-  assert(setEqual(A, B));
-}
-
-function setEqual(A, B) {
-  if (!(A instanceof Set)) throw new Error("not a set");
-  for (const a of A) if (!B.has(a)) return false;
-  for (const b of B) if (!A.has(b)) return false;
-  return true;
+export function assertSetEqual(actual, expected) {
+  assert(actual instanceof Set);
+  expected = new InternSet(expected);
+  for (const a of actual) assert(expected.has(a), `unexpected ${a}`);
+  for (const e of expected) assert(actual.has(e), `expected ${e}`);
 }

--- a/test/difference-test.js
+++ b/test/difference-test.js
@@ -2,11 +2,17 @@ import {difference} from "../src/index.js";
 import {assertSetEqual} from "./asserts.js";
 
 it("difference(values, other) returns a set of values", () => {
-  assertSetEqual(difference([1, 2, 3], [2, 1]), new Set([3]));
-  assertSetEqual(difference([1, 2], [2, 3, 1]), new Set([]));
-  assertSetEqual(difference([2, 1, 3], [4, 3, 1]), new Set([2]));
+  assertSetEqual(difference([1, 2, 3], [2, 1]), [3]);
+  assertSetEqual(difference([1, 2], [2, 3, 1]), []);
+  assertSetEqual(difference([2, 1, 3], [4, 3, 1]), [2]);
 });
 
 it("difference(...values) accepts iterables", () => {
-  assertSetEqual(difference(new Set([1, 2, 3]), new Set([1])), new Set([2, 3]));
+  assertSetEqual(difference(new Set([1, 2, 3]), new Set([1])), [2, 3]);
+});
+
+it("difference(values, other) performs interning", () => {
+  assertSetEqual(difference([new Date("2021-01-01"), new Date("2021-01-02"), new Date("2021-01-03")], [new Date("2021-01-02"), new Date("2021-01-01")]), [new Date("2021-01-03")]);
+  assertSetEqual(difference([new Date("2021-01-01"), new Date("2021-01-02")], [new Date("2021-01-02"), new Date("2021-01-03"), new Date("2021-01-01")]), []);
+  assertSetEqual(difference([new Date("2021-01-02"), new Date("2021-01-01"), new Date("2021-01-03")], [new Date("2021-01-04"), new Date("2021-01-03"), new Date("2021-01-01")]), [new Date("2021-01-02")]);
 });

--- a/test/disjoint-test.js
+++ b/test/disjoint-test.js
@@ -15,6 +15,12 @@ it("disjoint(values, other) allows other to be infinite", () => {
   assert.strictEqual(disjoint([2], repeat(1, 3, 2)), false);
 });
 
+it("disjoint(values, other) performs interning", () => {
+  assert.strictEqual(disjoint([new Date("2021-01-01")], [new Date("2021-01-02")]), true);
+  assert.strictEqual(disjoint([new Date("2021-01-02"), new Date("2021-01-03")], [new Date("2021-01-03"), new Date("2021-01-04")]), false);
+  assert.strictEqual(disjoint([new Date("2021-01-01")], []), true);
+});
+
 function* odds() {
   for (let i = 1; true; i += 2) {
     yield i;

--- a/test/intersection-test.js
+++ b/test/intersection-test.js
@@ -2,18 +2,22 @@ import {intersection} from "../src/index.js";
 import {assertSetEqual} from "./asserts.js";
 
 it("intersection(values) returns a set of values", () => {
-  assertSetEqual(intersection([1, 2, 3, 2, 1]), new Set([1, 2, 3]));
+  assertSetEqual(intersection([1, 2, 3, 2, 1]), [1, 2, 3]);
 });
 
 it("intersection(values, other) returns a set of values", () => {
-  assertSetEqual(intersection([1, 2], [2, 3, 1]), new Set([1, 2]));
-  assertSetEqual(intersection([2, 1, 3], [4, 3, 1]), new Set([1, 3]));
+  assertSetEqual(intersection([1, 2], [2, 3, 1]), [1, 2]);
+  assertSetEqual(intersection([2, 1, 3], [4, 3, 1]), [1, 3]);
 });
 
 it("intersection(...values) returns a set of values", () => {
-  assertSetEqual(intersection([1, 2], [2, 1], [2, 3]), new Set([2]));
+  assertSetEqual(intersection([1, 2], [2, 1], [2, 3]), [2]);
 });
 
 it("intersection(...values) accepts iterables", () => {
-  assertSetEqual(intersection(new Set([1, 2, 3])), new Set([1, 2, 3]));
+  assertSetEqual(intersection(new Set([1, 2, 3])), [1, 2, 3]);
+});
+
+it("intersection(...values) performs interning", () => {
+  assertSetEqual(intersection([new Date("2021-01-01"), new Date("2021-01-03")], [new Date("2021-01-01"), new Date("2021-01-02")]), [new Date("2021-01-01")]);
 });

--- a/test/subset-test.js
+++ b/test/subset-test.js
@@ -6,3 +6,9 @@ it("subset(values, other) returns true if values is a subset of others", () => {
   assert.strictEqual(subset([3, 4], [2, 3]), false);
   assert.strictEqual(subset([], [1]), true);
 });
+
+it("subset(values, other) performs interning", () => {
+  assert.strictEqual(subset([new Date("2021-01-02")], [new Date("2021-01-01"), new Date("2021-01-02")]), true);
+  assert.strictEqual(subset([new Date("2021-01-03"), new Date("2021-01-04")], [new Date("2021-01-02"), new Date("2021-01-03")]), false);
+  assert.strictEqual(subset([], [new Date("2021-01-01")]), true);
+});

--- a/test/superset-test.js
+++ b/test/superset-test.js
@@ -15,6 +15,12 @@ it("superset(values, other) allows other to be infinite", () => {
   assert.strictEqual(superset([1, 3, 5], repeat(1, 3, 2)), false);
 });
 
+it("superset(values, other) performs interning", () => {
+  assert.strictEqual(superset([new Date("2021-01-01"), new Date("2021-01-02")], [new Date("2021-01-02")]), true);
+  assert.strictEqual(superset([new Date("2021-01-02"), new Date("2021-01-03")], [new Date("2021-01-03"), new Date("2021-01-04")]), false);
+  assert.strictEqual(superset([new Date("2021-01-01")], []), true);
+});
+
 function* odds() {
   for (let i = 1; true; i += 2) {
     yield i;

--- a/test/union-test.js
+++ b/test/union-test.js
@@ -2,18 +2,23 @@ import {union} from "../src/index.js";
 import {assertSetEqual} from "./asserts.js";
 
 it("union(values) returns a set of values", () => {
-  assertSetEqual(union([1, 2, 3, 2, 1]), new Set([1, 2, 3]));
+  assertSetEqual(union([1, 2, 3, 2, 1]), [1, 2, 3]);
 });
 
 it("union(values, other) returns a set of values", () => {
-  assertSetEqual(union([1, 2], [2, 3, 1]), new Set([1, 2, 3]));
+  assertSetEqual(union([1, 2], [2, 3, 1]), [1, 2, 3]);
 });
 
 it("union(...values) returns a set of values", () => {
-  assertSetEqual(union([1], [2], [2, 3], [1]), new Set([1, 2, 3]));
+  assertSetEqual(union([1], [2], [2, 3], [1]), [1, 2, 3]);
 });
 
 it("union(...values) accepts iterables", () => {
-  assertSetEqual(union(new Set([1, 2, 3])), new Set([1, 2, 3]));
-  assertSetEqual(union(Uint8Array.of(1, 2, 3)), new Set([1, 2, 3]));
+  assertSetEqual(union(new Set([1, 2, 3])), [1, 2, 3]);
+  assertSetEqual(union(Uint8Array.of(1, 2, 3)), [1, 2, 3]);
+});
+
+it("union(...values) performs interning", () => {
+  assertSetEqual(union([new Date("2021-01-01"), new Date("2021-01-01"), new Date("2021-01-02")]), [new Date("2021-01-01"), new Date("2021-01-02")]);
+  assertSetEqual(union([new Date("2021-01-01"), new Date("2021-01-03")], [new Date("2021-01-01"), new Date("2021-01-02")]), [new Date("2021-01-01"), new Date("2021-01-02"), new Date("2021-01-03")]);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -824,9 +824,9 @@ inherits@2:
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
 "internmap@1 - 2":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/internmap/-/internmap-2.0.1.tgz#33d0fa016185397549fb1a14ea3dbe5a2949d1cd"
-  integrity sha512-Ujwccrj9FkGqjbY3iVoxD1VV+KdZZeENx0rphrtzmRXbFvkFO88L80BL/zeSIguX/7T+y8k04xqtgWgS5vxwxw==
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/internmap/-/internmap-2.0.2.tgz#3efa1165209cc56133df1400df9c34a73e0dad93"
+  integrity sha512-6O4dJQZN4+83kg9agi21fbasiAn7V2JRvLv29/YT1Kz8f+ngakB1hMG+AP0mYquLOtjWhNO8CvKhhXT/7Tla/g==
 
 is-binary-path@~2.1.0:
   version "2.1.0"


### PR DESCRIPTION
This adopts InternSet for d3-array’s set operations, which means you can now use things like d3.union and d3.difference on arrays of dates. As another bonus, you can say `d3.union(values)` instead of `new d3.InternSet(values)`.