### PR TITLE
Use the commonjs module as the main export

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "src/**/*.js"
   ],
   "module": "src/index.js",
-  "main": "src/index.js",
+  "main": "dist/d3-array.js",
   "jsdelivr": "dist/d3-array.min.js",
   "unpkg": "dist/d3-array.min.js",
   "exports": {


### PR DESCRIPTION
The ESM module is still exposed through the dedicated `module` property though for consumers that support it.