### PR TITLE
Use a syntax that can be transpiled by sucrase

### DIFF
--- a/src/cumsum.js
+++ b/src/cumsum.js
@@ -1,6 +1,6 @@
 export default function cumsum(values, valueof) {
   var sum = 0, index = 0;
   return Float64Array.from(values, valueof === undefined
-    ? v => (sum += +v || 0)
-    : v => (sum += +valueof(v, index++, values) || 0));
+    ? (v) => (sum += +v || 0)
+    : (v) => (sum += +valueof(v, index++, values) || 0));
 }


### PR DESCRIPTION
The minimal syntax used in `cumsum.js` is hard to parse and made it so that Sucrase, a fast transpiler that come in really handy for large projects, couldn't use anything that directly used this file

This is a small change that makes this big problem go away

https://github.com/alangpierce/sucrase/issues/666
[Sucrase can't transpile](https://sucrase.io/#compressedCode=H4sIAPDg1WEAA2WNzQqDMBAG7z7FdzREiofSQyUtXvoewSQgaFLWbLDUvnvjz6k97S7DzNr5GSjCWKd5iHDsu9gHj47Hiccy6YHtVGGbwQm8C%2BSDkCEU6gq9N3Ze1yYTspHJ4zEEHS%2Fnlki%2FTo7CXwdKKXA2Xe%2BtySJwR4K6oVzDUkEmLAtqsbHrL9srZTreS3mUJ7Fboik%2BX9IsTqnaAAAA)
[Sucrase can transpile](https://sucrase.io/#compressedCode=H4sIAMXg1WEAA2WOzQqDMBAG7z7Fd0yIFA%2Blh0pavPQ9giYgaFLWbLDUvnvjz83T7jLMsHZ%2BB4rorDM8RDj2beyDR8vjxKNIZmA7ldhmcBLfAvkgZAiNqkTvOzuva50J2cjk8RqCibdrQ2Q%2BF0fh1IHWGpxN13vbZRF4QiQJ%2FYBY00pDJSwLKrnR%2B5nuJZGOF5Q66pPcPVkXvz9PK4B13gAAAA%3D%3D)