### PR TITLE
fix Scott’s rule

### DIFF
--- a/src/threshold/scott.js
+++ b/src/threshold/scott.js
@@ -2,5 +2,5 @@ import count from "../count.js";
 import deviation from "../deviation.js";
 
 export default function thresholdScott(values, min, max) {
-  return Math.ceil((max - min) / (3.5 * deviation(values) * Math.pow(count(values), -1 / 3)));
+  return Math.ceil((max - min) / (3.49 * deviation(values) * Math.pow(count(values), -1 / 3)));
 }


### PR DESCRIPTION
I’m not sure how this happened, but all the literature uses 3.49, but d3-array used 3.5 for some reason.

I also thought about switching to `Math.cbrt(1 / count(values))` but I’m not sure if that’s an improvement.