### PR TITLE
fix crash on missing top bin

### DIFF
--- a/src/bin.js
+++ b/src/bin.js
@@ -84,8 +84,10 @@ export default function bin() {
     if (isFinite(step)) {
       if (step > 0) {
         for (i = 0; i < n; ++i) {
-          if ((x = values[i]) != null && x0 <= x && x <= x1) {
+          if ((x = values[i]) != null && x0 <= x && x < x1) {
             bins[Math.floor((x - x0) / step)].push(data[i]);
+          } else if (x === x1) {
+            bins[bins.length - 1].push(data[i]);
           }
         }
       } else if (step < 0) {

--- a/test/bin-test.js
+++ b/test/bin-test.js
@@ -235,6 +235,10 @@ it("bin(data) assigns floating point values to the correct bins", () => {
   }
 });
 
+it("bin(data) assigns integer values to the correct bins", () => {
+  assert.deepStrictEqual(bin().domain([4, 5])([5]), [box([5], 4, 5)]);
+});
+
 function box(bin, x0, x1)  {
   bin.x0 = x0;
   bin.x1 = x1;


### PR DESCRIPTION
`d3.bin().domain([4, 5])([5])` crashes

the issue is that we have removed the last bin, but then want to assign the largest value to it because floor(x1) === x1
I'm not sure if the fix catches all cases…

issue reported by weiglemc at https://observablehq.com/@weiglemc/demonstrating-issue-with-d3-bins-in-d3v7-4-1-update