### PR TITLE
fix comparator bisector

### DIFF
--- a/src/bisector.js
+++ b/src/bisector.js
@@ -2,35 +2,36 @@ import ascending from "./ascending.js";
 
 export default function bisector(f) {
   let delta = f;
-  let compare1 = f;
-  let compare2 = f;
+  let compare = f;
 
+  // If an accessor is specified, promote it to a comparator.
   if (f.length !== 2) {
     delta = (d, x) => f(d) - x;
-    compare1 = ascending;
-    compare2 = (d, x) => ascending(f(d), x);
+    compare = (d, x) => ascending(f(d), x);
   }
 
   function left(a, x, lo = 0, hi = a.length) {
     if (lo < hi) {
-      if (compare1(x, x) !== 0) return hi;
+      let ohi = hi, c;
       do {
         const mid = (lo + hi) >>> 1;
-        if (compare2(a[mid], x) < 0) lo = mid + 1;
+        if ((c = compare(a[mid], x)) < 0) lo = mid + 1;
         else hi = mid;
       } while (lo < hi);
+      if (!(c <= c)) return ohi; // x is not orderable
     }
     return lo;
   }
 
   function right(a, x, lo = 0, hi = a.length) {
     if (lo < hi) {
-      if (compare1(x, x) !== 0) return hi;
+      let ohi = hi, c;
       do {
         const mid = (lo + hi) >>> 1;
-        if (compare2(a[mid], x) <= 0) lo = mid + 1;
+        if ((c = compare(a[mid], x)) <= 0) lo = mid + 1;
         else hi = mid;
       } while (lo < hi);
+      if (!(c <= c)) return ohi; // x is not orderable
     }
     return lo;
   }

--- a/test/bisector-test.js
+++ b/test/bisector-test.js
@@ -151,6 +151,34 @@ it("bisector(comparator).right(array, value) handles large sparse d3", () => {
   assert.strictEqual(bisectRight(boxes, box(6), i - 5, i), i - 0);
 });
 
+it("bisector(comparator).left(array, value) supports an asymmetric (object, value) comparator", () => {
+  const boxes = [1, 2, 3].map(box);
+  const bisectLeft = bisector(ascendingBoxValue).left;
+  assert.strictEqual(bisectLeft(boxes, 1), 0);
+  assert.strictEqual(bisectLeft(boxes, 2), 1);
+  assert.strictEqual(bisectLeft(boxes, 3), 2);
+});
+
+it("bisector(comparator).left(array, value) keeps non-comparable values to the right", () => {
+  const boxes = [1, 2, null, undefined, NaN].map(box);
+  const bisectLeft = bisector(ascendingBox).left;
+  assert.strictEqual(bisectLeft(boxes, box(1)), 0);
+  assert.strictEqual(bisectLeft(boxes, box(2)), 1);
+  assert.strictEqual(bisectLeft(boxes, box(null)), 5);
+  assert.strictEqual(bisectLeft(boxes, box(undefined)), 5);
+  assert.strictEqual(bisectLeft(boxes, box(NaN)), 5);
+});
+
+it("bisector(accessor).left(array, value) keeps non-comparable values to the right", () => {
+  const boxes = [1, 2, null, undefined, NaN].map(box);
+  const bisectLeft = bisector(unbox).left;
+  assert.strictEqual(bisectLeft(boxes, 1), 0);
+  assert.strictEqual(bisectLeft(boxes, 2), 1);
+  assert.strictEqual(bisectLeft(boxes, null), 5);
+  assert.strictEqual(bisectLeft(boxes, undefined), 5);
+  assert.strictEqual(bisectLeft(boxes, NaN), 5);
+});
+
 it("bisector(accessor).left(array, value) returns the index of an exact match", () => {
   const boxes = [1, 2, 3].map(box);
   const bisectLeft = bisector(unbox).left;
@@ -345,4 +373,8 @@ function unbox(box) {
 
 function ascendingBox(a, b) {
   return ascending(a.value, b.value);
+}
+
+function ascendingBoxValue(a, value) {
+  return ascending(a.value, value);
 }


### PR DESCRIPTION
Fixes #249. Previously #227.

If the bisector was given an asymmetric comparator that takes (_object_, _value_) as arguments, then the test for whether the search value is orderable was failing because it would pass the comparator (_value_, _value_), which the comparator likely did not expect, and thus would typically return NaN or undefined.

So instead, we now perform the bisection without first testing for orderability, but if the final comparison at the end of bisection returns NaN, we know that the search value was not orderable. In the case that the search value is not orderable, this is obviously slower since we still perform the bisection, but we don’t need to optimize for this case and it’s better to be correct and backwards-compatible.