### PR TITLE
Hybrid ESM / CommonJS package - support both 'import' and 'require'

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,15 +25,16 @@
   },
   "type": "module",
   "files": [
-    "dist/**/*.js",
+    "dist",
     "src/**/*.js"
   ],
   "module": "src/index.js",
-  "main": "src/index.js",
+  "main": "dist/d3-array.min.cjs",
   "jsdelivr": "dist/d3-array.min.js",
   "unpkg": "dist/d3-array.min.js",
   "exports": {
     "umd": "./dist/d3-array.min.js",
+    "require": "./dist/d3-array.min.cjs",
     "default": "./src/index.js"
   },
   "sideEffects": false,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -49,5 +49,28 @@ export default [
         }
       })
     ]
+  },
+  {
+    ...config,
+    output: {
+      ...config.output,
+      file: `dist/${meta.name}.min.cjs`,
+      format: "cjs",
+      sourcemap: true
+    },
+    plugins: [
+      ...config.plugins,
+      terser({
+        output: {
+          preamble: config.output.banner
+        },
+        mangle: {
+          reserved: [
+            "InternMap",
+            "InternSet"
+          ]
+        }
+      })
+    ]
   }
 ];


### PR DESCRIPTION
Since the recent module format change to the d3 packages,
I've been unable to update to the latest version of some of them because I need to be 
able to `require` them in Node, but also to use them with tree-shaking bundlers,
in my packages that are published in both ESM and CJS format.

Would you have any issues with the following approach to restoring the `require` support and using package.json conditional `exports` or `module`/`main` to support both ES and CommonJS modules?

----------

I made some changes to rollup config to add an additional CommonJS output with the `.cjs` extension (with a source map for debugging),
and updated package.json to point `require` to the CJS script while leaving `import` behavior unchanged.
Older versions of node and -- as far as I know -- the major bundlers should have no problems with this.

I considered just copying the UMD JS file to .cjs, but I wanted to be able to have a source map for the minified script and didn't want to add that to the UMD.  

I have forked versions of all or most of the d3 packages with this update applied, but I wanted to submit the PR here first instead of spamming every repo.