### PR TITLE
blur2 with stride

### DIFF
--- a/src/blur.js
+++ b/src/blur.js
@@ -11,37 +11,40 @@ export function blur1(values, r) {
   return values;
 }
 
-export function blur2(values, width, rx, ry = rx) {
+export function blur2(values, width, rx, ry = rx, stride = 1) {
   if (!((rx = +rx) >= 0)) throw new RangeError("invalid rx");
   if (!((ry = +ry) >= 0)) throw new RangeError("invalid ry");
   if (!((width = Math.floor(width)) >= 0)) throw new RangeError("invalid width");
+  if (!((stride = Math.floor(stride)) > 0)) throw new RangeError("invalid stride");
   if (!width || (!rx && !ry)) return values;
   const temp = values.slice();
-  const height = Math.floor(values.length / width);
+  const height = Math.floor(values.length / width / stride);
   const blurx = blurf(rx);
   const blury = blurf(ry);
   if (rx && ry) {
-    blurh(blurx, temp, values, width, height);
-    blurh(blurx, values, temp, width, height);
-    blurh(blurx, temp, values, width, height);
-    blurv(blury, values, temp, width, height);
-    blurv(blury, temp, values, width, height);
-    blurv(blury, values, temp, width, height);
+    blurh(blurx, temp, values, width, height, stride);
+    blurh(blurx, values, temp, width, height, stride);
+    blurh(blurx, temp, values, width, height, stride);
+    blurv(blury, values, temp, width * stride, height);
+    blurv(blury, temp, values, width * stride, height);
+    blurv(blury, values, temp, width * stride, height);
   } else if (rx) {
-    blurh(blurx, values, temp, width, height);
-    blurh(blurx, temp, values, width, height);
-    blurh(blurx, values, temp, width, height);
+    blurh(blurx, values, temp, width, height, stride);
+    blurh(blurx, temp, values, width, height, stride);
+    blurh(blurx, values, temp, width, height, stride);
   } else if (ry) {
-    blurv(blury, values, temp, width, height);
-    blurv(blury, temp, values, width, height);
-    blurv(blury, values, temp, width, height);
+    blurv(blury, values, temp, width * stride, height);
+    blurv(blury, temp, values, width * stride, height);
+    blurv(blury, values, temp, width * stride, height);
   }
   return values;
 }
 
-function blurh(blur, T, S, w, h) {
-  for (let y = 0, n = w * h; y < n;) {
-    blur(T, S, y, y += w, 1);
+function blurh(blur, T, S, w, h, stride = 1) {
+  for (let a = 0; a < stride; ++a) {
+    for (let y = a, n = w * h * stride; y < n;) {
+      blur(T, S, y, y += w * stride, stride);
+    }
   }
 }
 

--- a/test/blur-test.js
+++ b/test/blur-test.js
@@ -206,3 +206,40 @@ it("blur2(values, width, 0, ry) does vertical blurring", () => {
 function round(x) {
   return Math.round(x * 1000) / 1000 || 0;
 }
+
+// a stride on blur1 is the same as using a vertical blur2 with width=stride 
+it("blur1 & stride", () => {
+  const values = [-27,270,-2700,27000, 0,0,0,0];
+  assert.deepStrictEqual(blur2(values, 4, 0, 1), [-14,140,-1400,14000, -13,130,-1300,13000]);
+});
+
+it("blur2 & stride", () => {
+  assert.deepStrictEqual(blur2([
+    729,0,0,0, 0,0,0,0,
+    0,0,0,0, 0,0,0,0
+  ], 2, 1, 1, 4), [
+    196,0,0,0, 182,0,0,0,
+    182,0,0,0, 169,0,0,0
+  ]);
+  assert.deepStrictEqual(blur2([
+    0,729,0,0, 0,0,0,0,
+    0,0,0,0, 0,0,0,0
+  ], 2, 1, 1, 4), [
+    0,196,0,0, 0,182,0,0,
+    0,182,0,0, 0,169,0,0
+  ]);
+  assert.deepStrictEqual(blur2([
+    0,0,729,0, 0,0,0,0,
+    0,0,0,0, 0,0,0,0
+  ], 2, 1, 1, 4), [
+    0,0,196,0, 0,0,182,0,
+    0,0,182,0, 0,0,169,0
+  ]);
+  assert.deepStrictEqual(blur2([
+    0,0,0,729, 0,0,0,0,
+    0,0,0,0, 0,0,0,0
+  ], 2, 1, 1, 4), [
+    0,0,0,196, 0,0,0,182,
+    0,0,0,182, 0,0,0,169
+  ]);
+});


### PR DESCRIPTION
demo https://observablehq.com/@d3/blur-stride-dev

The API will have to change: having the stride at the end after the optional ry is not the best solution.

There is no need to change blur1 to accept a stride parameter, since it is the same as using blur2 with width=stride, rx=0, ry=r. We can intercept this in the API if we want, for consistency.