### PR TITLE
fix(jest-integration): add `require` to `exports`

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "jsdelivr": "dist/d3-array.min.js",
   "unpkg": "dist/d3-array.min.js",
   "exports": {
+    "require": "./dist/d3-array.min.js",
     "umd": "./dist/d3-array.min.js",
     "default": "./src/index.js"
   },


### PR DESCRIPTION
Fixes:
- https://github.com/d3/d3-array/issues/255

Perhaps worth expanding this fix on the remaining libs from the `d3-*` package family.

---

This change follows the advice from:
- https://github.com/facebook/jest/issues/12036#issuecomment-1039479569

Tested locally: the change fixes the problem with `jest` trying to use the `default` path.