### PR TITLE
Change main entrypoint to dist/index.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "src/**/*.js"
   ],
   "module": "src/index.js",
-  "main": "src/index.js",
+  "main": "dist/index.js",
   "jsdelivr": "dist/d3-array.min.js",
   "unpkg": "dist/d3-array.min.js",
   "exports": {


### PR DESCRIPTION
Provides compatibility with tooling which does not support modules (e.g. Jest). Module exports are already available in "module" for tools which can support them.

Fixes #255