### PR TITLE
Infinite loop calling quantile without p

### DIFF
--- a/src/quickselect.js
+++ b/src/quickselect.js
@@ -3,6 +3,7 @@ import {ascendingDefined, compareDefined} from "./sort.js";
 // Based on https://github.com/mourner/quickselect
 // ISC license, Copyright 2018 Vladimir Agafonkin.
 export default function quickselect(array, k, left = 0, right = array.length - 1, compare) {
+  if (!Number.isInteger(k)) throw new TypeError("k is not an integer");
   compare = compare === undefined ? ascendingDefined : compareDefined(compare);
 
   while (right > left) {


### PR DESCRIPTION
e.g.

```
> quantile([1,2,3])                                                             
^CUncaught Error: Script execution was interrupted by `SIGINT`
```

While the quantile function might wish to define a specific error or default behavior, the underlying cause is quickselect shuffling elements between integral indices and "undefined"; this is obviously nonsensical and quickselect should instead complain about an invalid pivot index.